### PR TITLE
Fixes for the Tutorials TOC and "Drill in 10 Minutes."

### DIFF
--- a/_docs/tutorials/010-tutorials-introduction.md
+++ b/_docs/tutorials/010-tutorials-introduction.md
@@ -4,30 +4,29 @@ parent: "Tutorials"
 ---
 If you've never used Drill, use these tutorials to download, install, and start working with Drill. The tutorials include step-by-step procedures for the following tasks:
 
-* [Drill in 10 Minutes]({{site.baseurl}}/docs/drill-in-10-minutes)  
-  Download and install Drill in embedded mode, which means you use a single-node cluster.  
-* [Analyzing the Yelp Academic Dataset]({{site.baseurl}}/docs/analyzing-the-yelp-academic-dataset)  
-  Download and install Drill in embedded mode and use SQL examples to analyze Yelp data.  
-* [Learn Drill with the MapR Sandbox]({{site.baseurl}}/docs/about-the-mapr-sandbox)  
-  Explore data using a Hadoop environment pre-configured with Drill.  
-* [Analyzing Highly Dynamic Datasets]({{site.baseurl}}/docs/analyzing-highly-dynamic-datasets)  
+* [Drill in 10 Minutes]({{site.baseurl}}/docs/drill-in-10-minutes)
+  Download and install Drill in embedded mode, which means you use a single-node cluster.
+* [Analyzing the Yelp Academic Dataset]({{site.baseurl}}/docs/analyzing-the-yelp-academic-dataset)
+  Download and install Drill in embedded mode and use SQL examples to analyze Yelp data.
+* [Learn Drill with the MapR Sandbox]({{site.baseurl}}/docs/about-the-mapr-sandbox)
+  Explore data using a Hadoop environment pre-configured with Drill.
+* [Analyzing Highly Dynamic Datasets]({{site.baseurl}}/docs/analyzing-highly-dynamic-datasets)
   Delve into changing data without creating a schema or going through an ETL phase.
-* [Analyzing Social Media]({{site.baseurl}}/docs/analyzing-social-media)  
-  Analyze Twitter data in native JSON format using Apache Drill.  
-* [Tableau Examples]({{site.baseurl}}/docs/tableau-examples)  
-  Access Hive tables in Tableau.  
-* [Using MicroStrategy Analytics with Apache Drill]({{site.baseurl}}/docs/using-microstrategy-analytics-with-apache-drill/)  
-  Use the Drill ODBC driver from MapR to analyze data and generate a report using Drill from the MicroStrategy UI.  
-* [Using Tibco Spotfire Server with Drill]({{site.baseurl}}/docs/using-tibco-spotfire-with-drill/)  
-  Use the Apache Drill to query complex data structures from Tibco Spotfire Desktop.
-* [Configuring Tibco Spotfire Server with Drill]({{site.baseurl}}/docs/configuring-tibco-spotfire-server-with-drill)  
-  Integrate Tibco Spotfire Server with Apache Drill and explore multiple data formats on Hadoop.  
-* [Using Apache Drill with Tableau 9 Desktop]({{site.baseurl}}/docs/using-apache-drill-with-tableau-9-desktop)  
-  Connect Tableau 9 Desktop to Apache Drill, explore multiple data formats on Hadoop, and access semi-structured data.  
-* [Using Apache Drill with Tableau 9 Server]({{site.baseurl}}/docs/using-apache-drill-with-tableau-9-server)  
-  Connect Tableau 9 Server to Apache Drill, explore multiple data formats on Hadoop, access semi-structured data, and share Tableau visualizations with others.  
-* [Using Drill to Analyze Amazon Spot Prices](https://github.com/vicenteg/spot-price-history#drill-workshop---amazon-spot-prices)  
-  A Drill workshop on github that covers views of JSON and Parquet data.  
-* [Running Drill Queries on S3 Data](http://drill.apache.org/blog/2014/12/09/running-sql-queries-on-amazon-s3/)  
-  Nick Amato's blog that steps through querying files using Drill and Amazon Simple Storage Service (S3).  
-
+* [Analyzing Social Media]({{site.baseurl}}/docs/analyzing-social-media)
+  Analyze Twitter data in native JSON format using Apache Drill.
+* [Tableau Examples]({{site.baseurl}}/docs/tableau-examples)
+  Access Hive tables in Tableau.
+* [Using MicroStrategy Analytics with Apache Drill]({{site.baseurl}}/docs/using-microstrategy-analytics-with-apache-drill/)
+  Use the Drill ODBC driver from MapR to analyze data and generate a report using Drill from the MicroStrategy UI.
+* [Using Tibco Spotfire Server with Drill]({{site.baseurl}}/docs/using-tibco-spotfire-with-drill/)
+  Use Apache Drill to query complex data structures from Tibco Spotfire Desktop.
+* [Configuring Tibco Spotfire Server with Drill]({{site.baseurl}}/docs/configuring-tibco-spotfire-server-with-drill)
+  Integrate Tibco Spotfire Server with Apache Drill and explore multiple data formats on Hadoop.
+* [Using Apache Drill with Tableau 9 Desktop]({{site.baseurl}}/docs/using-apache-drill-with-tableau-9-desktop)
+  Connect Tableau 9 Desktop to Apache Drill, explore multiple data formats on Hadoop, and access semi-structured data.
+* [Using Apache Drill with Tableau 9 Server]({{site.baseurl}}/docs/using-apache-drill-with-tableau-9-server)
+  Connect Tableau 9 Server to Apache Drill, explore multiple data formats on Hadoop, access semi-structured data, and share Tableau visualizations with others.
+* [Using Drill to Analyze Amazon Spot Prices](https://github.com/vicenteg/spot-price-history#drill-workshop---amazon-spot-prices)
+  A Drill workshop on github that covers views of JSON and Parquet data.
+* [Running Drill Queries on S3 Data](http://drill.apache.org/blog/2014/12/09/running-sql-queries-on-amazon-s3/)
+  Nick Amato's blog that steps through querying files using Drill and Amazon Simple Storage Service (S3).

--- a/_docs/tutorials/020-drill-in-10-minutes.md
+++ b/_docs/tutorials/020-drill-in-10-minutes.md
@@ -21,12 +21,12 @@ After installing Drill, you start the Drill shell. The Drill shell is a pure-Jav
 
 You need to meet the following prerequisites to run Drill:
 
-* Linux, Mac OS X, and Windows: [Oracle Java SE Development (JDK) Kit 7](http://www.oracle.com/technetwork/java/javase/downloads/jdk7-downloads-1880260.html) installation  
-* Windows only:  
-  * A JAVA_HOME environment variable set up that points to  to the JDK installation  
-  * A PATH environment variable that includes a pointer to the JDK installation  
-  * A third-party utility for unzipping a tar.gz file 
-  
+* Linux, Mac OS X, and Windows: [Oracle Java SE Development (JDK) Kit 7](http://www.oracle.com/technetwork/java/javase/downloads/jdk7-downloads-1880260.html) installation
+* Windows only:
+  * A JAVA_HOME environment variable set up that points to  to the JDK installation
+  * A PATH environment variable that includes a pointer to the JDK installation
+  * A third-party utility for unzipping a tar.gz file
+
 ### Java Installation Prerequisite Check
 
 Run the following command in a terminal (Linux and Mac OS X) or Command Prompt (Windows) to verify that Java 7 is the version in effect:
@@ -41,17 +41,22 @@ The output looks something like this:
 
 ## Install Drill on Linux or Mac OS X
 
-Complete the following steps to install Drill:  
+Complete the following steps to install Drill:
 
-1. Issue the following command in a terminal to download the latest version of Apache Drill to a directory on your machine, or download Drill from the [Drill web site](http://getdrill.org/drill/download/apache-drill-1.0.0.tar.gz):
+1. In a terminal window, navigate (cd) to the directory where you want to install Drill.
 
-        wget http://getdrill.org/drill/download/apache-drill-1.0.0.tar.gz  
+2. Issue one of the following two commands (some systems will have wget, and
+some will have curl) to download the latest version of Apache Drill, or download Drill from the [Drill web site](http://getdrill.org/drill/download/apache-drill-1.0.0.tar.gz):
 
-2. Copy the downloaded file to the directory where you want to install Drill. 
+        wget http://getdrill.org/drill/download/apache-drill-1.0.0.tar.gz
 
-3. Extract the contents of the Drill tar.gz file. Use sudo if necessary:  
+OR
 
-        sudo tar -xvzf apache-drill-1.0.0.tar.gz  
+        curl -o apache-drill-1.0.0.tar.gz http://getdrill.org/drill/download/apache-drill-1.0.0.tar.gz
+
+3. Extract the contents of the Drill tar.gz file. Use sudo if necessary:
+
+        sudo tar -xvzf apache-drill-1.0.0.tar.gz
 
 The extraction process creates the installation directory named apache-drill-1.0.0 containing the Drill software.
 
@@ -60,15 +65,23 @@ At this point, you can start Drill.
 ## Start Drill on Linux and Mac OS X
 Start Drill in embedded mode using the `drill-embedded` command:
 
-1. Navigate to the Drill installation directory. For example:  
+1. Navigate to the Drill installation directory. For example:
 
-        cd apache-drill-1.0.0  
+        cd apache-drill-1.0.0
 
 2. Issue the following command to launch Drill in embedded mode:
 
-        bin/drill-embedded  
+        bin/drill-embedded
 
-   The message of the day followed by the `0: jdbc:drill:zk=local>`  prompt appears.  
+   This starts *sqlline*, the command-line environment provided with Drill,
+   which supports submitting queries directly from a terminal. The message of
+   the day, followed by the `0: jdbc:drill:zk=local>` prompt appears.
+
+   NOTE TO DOCWRITERS: I tried this on 0.9.0 (because 1.0.0 isn't available
+   yet), and there is no bin/drill-embedded. In order to start it up, I had
+   to issue
+
+        bin/sqlline -u jdbc:drill:zk=local
 
    At this point, you can [submit queries]({{site.baseurl}}/docs/drill-in-10-minutes#query-sample-data) to Drill.
 
@@ -76,23 +89,23 @@ Start Drill in embedded mode using the `drill-embedded` command:
 
 You can install Drill on Windows 7 or 8. First, set the JAVA_HOME environment variable, and then install Drill. Complete the following steps to install Drill:
 
-1. Click the following link to download the latest version of Apache Drill:  [http://getdrill.org/drill/download/apache-drill-1.0.0.tar.gz](http://getdrill.org/drill/download/apache-drill-0.1.0.tar.gz)  
-2. Move the `apache-drill-1.0.0.tar.gz` file to a directory where you want to install Drill.  
-3. Unzip the `TAR.GZ` file using a third-party tool. If the tool you use does not unzip the TAR file as well as the `TAR.GZ` file, unzip the `apache-drill-1.0.0.tar` to extract the Drill software. The extraction process creates the installation directory named apache-drill-1.0.0 containing the Drill software. For example:  
+1. Click the following link to download the latest version of Apache Drill:  [http://getdrill.org/drill/download/apache-drill-1.0.0.tar.gz](http://getdrill.org/drill/download/apache-drill-0.1.0.tar.gz)
+2. Move the `apache-drill-1.0.0.tar.gz` file to a directory where you want to install Drill.
+3. Unzip the `TAR.GZ` file using a third-party tool. If the tool you use does not unzip the TAR file as well as the `TAR.GZ` file, unzip the `apache-drill-1.0.0.tar` to extract the Drill software. The extraction process creates the installation directory named apache-drill-1.0.0 containing the Drill software. For example:
    ![drill install dir]({{ site.baseurl }}/docs/img/drill-directory.png)
 
-At this point, you can start Drill.  
+At this point, you can start Drill.
 
 ## Start Drill on Windows
 Start Drill by running the sqlline.bat file and typing a connection string, as shown in the following procedure. The `zk=local` in the connection string means the local node is the ZooKeeper node:
 
-1. Open the apache-drill-1.0.0 folder.  
+1. Open the apache-drill-1.0.0 folder.
 2. Open the bin folder, and double-click the `sqlline.bat` file:
    ![drill bin dir]({{ site.baseurl }}/docs/img/drill-bin.png)
-   The Windows command prompt opens.  
+   The Windows command prompt opens.
 3. At the sqlline> prompt, type `!connect jdbc:drill:zk=local` and then press Enter:
    ![sqlline]({{ site.baseurl }}/docs/img/sqlline1.png)
-4. Enter the username, `admin`, and password, also `admin` when prompted.  
+4. Enter the username, `admin`, and password, also `admin` when prompted.
    The `0: jdbc:drill:zk=local>` prompt appears.
 At this point, you can [run queries]({{ site.baseurl }}/docs/drill-in-10-minutes#query-sample-data).
 
@@ -104,7 +117,7 @@ Issue the following command when you want to exit the Drill shell:
 
 ## Query Sample Data
 
-Your Drill installation includes a `sample-date` directory with JSON and
+Your Drill installation includes a `sample-data` directory with JSON and
 Parquet files that you can query. The local file system on your machine is
 configured as the `dfs` storage plugin instance by default when you install
 Drill in embedded mode. For more information about storage plugin
@@ -115,10 +128,15 @@ Use SQL syntax to query the sample `JSON` and `Parquet` files in the `sample-dat
 ### Querying a JSON File
 
 A sample JSON file, `employee.json`, contains fictitious employee data.
+NOTE TO DOC WRITERS: This sample query works, but I can't find the sample
+employee data in the installation (nor the storage plugin configuration file,
+which would point me in the right direction). Just like the Parquet example
+below, I'm sure people will want to know where this is coming from (in order to
+examine the source data themselves).
 
 To view the data in the `employee.json` file, submit the following SQL query
 to Drill:
-    
+
     0: jdbc:drill:zk=local> SELECT * FROM cp.`employee.json` LIMIT 3;
 
 The query output is:
@@ -139,24 +157,18 @@ directory on your local file system.
 
 #### Region File
 
-If you followed the Apache Drill in 10 Minutes instructions to install Drill
-in embedded mode, the path to the parquet file varies between operating
-systems.
+To view the data in the `region.parquet` file, issue the following query:
 
-{% include startnote.html %}When you enter the query, include the version of Drill that you are currently running.{% include endnote.html %} 
+{% include startnote.html %}When you enter the query, you will need to include
+the directory where you installed Drill, and the version of Drill that you installed in the angle-bracketed locations.{% include endnote.html %}
 
-To view the data in the `region.parquet` file, issue the query appropriate for
-your operating system:
+* Linux or Mac OS X
 
-* Linux  
+        SELECT * FROM dfs.`<path-to-installation>/apache-drill-<version>/sample-data/region.parquet`;
 
-        SELECT * FROM dfs.`/opt/drill/apache-drill-<version>/sample-data/region.parquet`;
-* Mac OS X
-  
-        SELECT * FROM dfs.`/Users/max/drill/apache-drill-<version>/sample-data/region.parquet`;
-* Windows  
-        
-        SELECT * FROM dfs.`C:\drill\apache-drill-<version>\sample-data\region.parquet`;
+* Windows
+
+        SELECT * FROM dfs.`<path-to-installation>\apache-drill-<version>\sample-data\region.parquet`;
 
 The query returns the following results:
 
@@ -173,25 +185,18 @@ The query returns the following results:
 
 #### Nation File
 
-If you followed the Apache Drill in 10 Minutes instructions to install Drill
-in embedded mode, the path to the parquet file varies between operating
-systems.
-
-{% include startnote.html %}When you enter the query, include the version of Drill that you are currently running.{% include endnote.html %}
+{% include startnote.html %}As above, you need to substitute your installation path and the Drill version in the angle-bracketed locations when you enter the query.{% include endnote.html %}
 
 To view the data in the `nation.parquet` file, issue the query appropriate for
 your operating system:
 
-* Linux  
+* Linux or Mac OS X
 
-          SELECT * FROM dfs.`/opt/drill/apache-drill-<version>/sample-data/nation.parquet`;
-* Mac OS X
-  
-          SELECT * FROM dfs.`/Users/max/drill/apache-drill-<version>/sample-data/nation.parquet`;
+          SELECT * FROM dfs.`<path-to-installation>/apache-drill-<version>/sample-data/nation.parquet`;
 
-* Windows 
- 
-          SELECT * FROM dfs.`C:\drill\apache-drill-<version>\sample-data\nation.parquet`;
+* Windows
+
+          SELECT * FROM dfs.`<path-to-installation>\apache-drill-<version>\sample-data\nation.parquet`;
 
 The query returns the following results:
 

--- a/_docs/tutorials/030-analyzing-the-yelp-academic-dataset.md
+++ b/_docs/tutorials/030-analyzing-the-yelp-academic-dataset.md
@@ -5,9 +5,9 @@ parent: "Tutorials"
 Apache Drill is one of the fastest growing open source projects, with the community making rapid progress with monthly releases. The key difference is Drill’s agility and flexibility.
 Along with meeting the table stakes for SQL-on-Hadoop, which is to achieve low
 latency performance at scale, Drill allows users to analyze the data without
-any ETL or up-front schema definitions. The data could be in any file format
-such as text, JSON, or Parquet. Data could have simple types such as string,
-integer, dates, or more complex multi-structured data, such as nested maps and
+any ETL or up-front schema definitions. The data can be in any file format
+such as text, JSON, or Parquet. Data can have simple types such as strings,
+integers, or dates, or more complex multi-structured data, such as nested maps and
 arrays. Data can exist in any file system, local or distributed, such as HDFS,
 MapR FS, or S3. Drill, has a “no schema” approach, which enables you to get
 value from your data in just a few minutes.
@@ -21,38 +21,26 @@ example is downloadable from [Yelp](http://www.yelp.com/dataset_challenge)
 
 ## Installing and Starting Drill
 
-### Step 1: Download Apache Drill onto your local machine
+In order to experiment with Drill locally, follow the installation instructions
+in [Drill in 10 Minutes]({{ site.baseurl }}/docs/drill-in-10-minutes).
 
-[http://drill.apache.org/download/](http://drill.apache.org/download/)
-
-You can also [in Drill in distributed mode]({{ site.baseurl }}/docs/installing-drill-in-distributed-mode) if you
-want to scale your environment.
-
-### Step 2 : Open the Drill tar file
-
-    tar -xvf apache-drill-0.1.0.tar.gz
-
-### Step 3: Start the Drill shell.
-
-    bin/drill-embedded
-
-That’s it! You are now ready explore the data.
+Alternatively, you can [install Drill in distributed mode]({{ site.baseurl }}/docs/installing-drill-in-distributed-mode) if you want to scale your environment.
 
 Let’s try out some SQL examples to understand how Drill makes the raw data
 analysis extremely easy.
 
-{% include startnote.html %}You need to substitute your local path to the Yelp data set in the FROM clause of each query you run.{% include endnote.html %}
+{% include startnote.html %}You need to substitute your local path to the Yelp data set in the angle-bracketed portion of the FROM clause of each query you run.{% include endnote.html %}
 
 ----------
 
-## Querying Data with Drill   
-   
+## Querying Data with Drill
+
 ### 1\. View the contents of the Yelp business data
 
     0: jdbc:drill:zk=local> !set maxwidth 10000
 
     0: jdbc:drill:zk=local> select * from
-        dfs.`/users/nrentachintala/Downloads/yelp/yelp_academic_dataset_business.json`
+        dfs.`<path-to-yelp-dataset>/yelp/yelp_academic_dataset_business.json`
         limit 1;
 
     +------------------------+----------------------------------------------------+------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+------+--------------------------------+---------+--------------+-------------------+-------------+-------+-------+-----------+--------------------------------------------------------------------------------------------------------------------------------------------------------------+----------+---------------+
@@ -69,8 +57,8 @@ You can directly query self-describing files such as JSON, Parquet, and text. Th
 
 #### Total reviews in the data set
 
-    0: jdbc:drill:zk=local> select sum(review_count) as totalreviews 
-    from dfs.`/users/nrentachintala/Downloads/yelp/yelp_academic_dataset_business.json`;
+    0: jdbc:drill:zk=local> select sum(review_count) as totalreviews
+    from dfs.`<path-to-yelp-dataset>/yelp/yelp_academic_dataset_business.json`;
 
     +--------------+
     | totalreviews |
@@ -80,8 +68,8 @@ You can directly query self-describing files such as JSON, Parquet, and text. Th
 
 #### Top states and cities in total number of reviews
 
-    0: jdbc:drill:zk=local> select state, city, count(*) totalreviews 
-    from dfs.`/users/nrentachintala/Downloads/yelp/yelp_academic_dataset_business.json` 
+    0: jdbc:drill:zk=local> select state, city, count(*) totalreviews
+    from dfs.`<path-to-yelp-dataset>/yelp/yelp_academic_dataset_business.json`
     group by state, city order by count(*) desc limit 10;
 
     +------------+------------+--------------+
@@ -101,8 +89,8 @@ You can directly query self-describing files such as JSON, Parquet, and text. Th
 
 #### Average number of reviews per business star rating
 
-    0: jdbc:drill:zk=local> select stars,trunc(avg(review_count)) reviewsavg 
-    from dfs.`/users/nrentachintala/Downloads/yelp/yelp_academic_dataset_business.json`
+    0: jdbc:drill:zk=local> select stars,trunc(avg(review_count)) reviewsavg
+    from dfs.`<path-to-yelp-dataset>/yelp/yelp_academic_dataset_business.json`
     group by stars order by stars desc;
 
     +------------+------------+
@@ -121,9 +109,9 @@ You can directly query self-describing files such as JSON, Parquet, and text. Th
 
 #### Top businesses with high review counts (> 1000)
 
-    0: jdbc:drill:zk=local> select name, state, city, `review_count` from
-    dfs.`/users/nrentachintala/Downloads/yelp/yelp_academic_dataset_business.json`
-    where review_count > 1000 order by `review_count` desc limit 10;
+    0: jdbc:drill:zk=local> select name, state, city, review_count from
+    dfs.`<path-to-yelp-dataset>/yelp/yelp_academic_dataset_business.json`
+    where review_count > 1000 order by review_count desc limit 10;
 
     +-------------------------------+-------------+------------+---------------+
     |           name                |   state     |    city    |  review_count |
@@ -143,10 +131,10 @@ You can directly query self-describing files such as JSON, Parquet, and text. Th
 #### Saturday open and close times for a few businesses
 
     0: jdbc:drill:zk=local> select b.name, b.hours.Saturday.`open`,
-    b.hours.Saturday.`close`  
+    b.hours.Saturday.`close`
     from
-    dfs.`/users/nrentachintala/Downloads/yelp/yelp_academic_dataset_business.json`
-    b limit 10;
+    dfs.`<path-to-yelp-dataset>/yelp/yelp_academic_dataset_business.json` b
+    limit 10;
 
     +----------------------------+------------+------------+
     |    name                    |   EXPR$1   |   EXPR$2   |
@@ -184,7 +172,9 @@ the data).
 
 Then, query the attribute’s data.
 
-    0: jdbc:drill:zk=local> select attributes from dfs.`/users/nrentachintala/Downloads/yelp/yelp_academic_dataset_business.json` limit 10;
+    0: jdbc:drill:zk=local> select attributes
+    from dfs.`<path-to-yelp-dataset>/yelp/yelp_academic_dataset_business.json`
+    limit 10;
 
     +-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
     |                                                     attributes                                                                                                                    |
@@ -217,7 +207,9 @@ on data.
 
 #### Number of restaurants in the data set
 
-    0: jdbc:drill:zk=local> select count(*) as TotalRestaurants from dfs.`/users/nrentachintala/Downloads/yelp/yelp_academic_dataset_business.json` where true=repeated_contains(categories,'Restaurants');
+    0: jdbc:drill:zk=local> select count(*) as TotalRestaurants
+    from dfs.`<path-to-yelp-dataset>/yelp/yelp_academic_dataset_business.json`
+    where true=repeated_contains(categories,'Restaurants');
     +------------------+
     | TotalRestaurants |
     +------------------+
@@ -226,7 +218,10 @@ on data.
 
 #### Top restaurants in number of reviews
 
-    0: jdbc:drill:zk=local> select name,state,city,`review_count` from dfs.`/users/nrentachintala/Downloads/yelp/yelp_academic_dataset_business.json` where true=repeated_contains(categories,'Restaurants') order by `review_count` desc limit 10;
+    0: jdbc:drill:zk=local> select name, state, city, `review_count`
+    from dfs.`<path-to-yelp-dataset>/yelp/yelp_academic_dataset_business.json`
+    where true=repeated_contains(categories,'Restaurants')
+    order by `review_count` desc limit 10;
 
     +------------------------+-------+-----------+--------------+
     |          name          | state |    city   | review_count |
@@ -245,7 +240,10 @@ on data.
 
 #### Top restaurants in number of listed categories
 
-    0: jdbc:drill:zk=local> select name,repeated_count(categories) as categorycount, categories from dfs.`/users/nrentachintala/Downloads/yelp/yelp_academic_dataset_business.json` where true=repeated_contains(categories,'Restaurants') order by repeated_count(categories) desc limit 10;
+    0: jdbc:drill:zk=local> select name,repeated_count(categories) as categorycount, categories
+    from dfs.`<path-to-yelp-dataset>/yelp/yelp_academic_dataset_business.json`
+    where true=repeated_contains(categories,'Restaurants')
+    order by repeated_count(categories) desc limit 10;
 
     +---------------------------------+---------------+---------------------------------------------------------------------------------------------------------------------------------------------------+
     | name                            | categorycount | categories                                                                                                                                        |
@@ -266,9 +264,9 @@ on data.
 
 #### Top first categories in number of review counts
 
-    0: jdbc:drill:zk=local> select categories[0], count(categories[0]) as categorycount 
-    from dfs.`/users/nrentachintala/Downloads/yelp_academic_dataset_business.json` 
-    group by categories[0] 
+    0: jdbc:drill:zk=local> select categories[0], count(categories[0]) as categorycount
+    from dfs.`<path-to-yelp-dataset>/yelp/yelp_academic_dataset_business.json`
+    group by categories[0]
     order by count(categories[0]) desc limit 10;
 
     +----------------------+---------------+
@@ -290,8 +288,9 @@ on data.
 
 #### Take a look at the contents of the Yelp reviews dataset.
 
-    0: jdbc:drill:zk=local> select * 
-    from dfs.`/users/nrentachintala/Downloads/yelp/yelp_academic_dataset_review.json` limit 1;
+    0: jdbc:drill:zk=local> select *
+    from dfs.`<path-to-yelp-dataset>/yelp/yelp_academic_dataset_review.json`
+    limit 1;
     +---------------------------------+------------------------+------------------------+-------+------------+----------------------------------------------------------------------+--------+------------------------+
     | votes                           | user_id                | review_id              | stars | date       | text                                                                 | type   | business_id            |
     +---------------------------------+------------------------+------------------------+-------+------------+----------------------------------------------------------------------+--------+------------------------+
@@ -301,15 +300,15 @@ on data.
 #### Top businesses with cool rated reviews
 
 Note that we are combining the Yelp business data set that has the overall
-review_count to the Yelp review data, which holds additional details on each
+review_count with the Yelp review data, which holds additional details on each
 of the reviews themselves.
 
-    0: jdbc:drill:zk=local> Select b.name 
-    from dfs.`/users/nrentachintala/Downloads/yelp/yelp_academic_dataset_business.json` b 
-    where b.business_id in (SELECT r.business_id 
-    FROM dfs.`/users/nrentachintala/Downloads/yelp/yelp_academic_dataset_review.json` r
-    GROUP BY r.business_id having sum(r.votes.cool) > 2000 
-    order by sum(r.votes.cool)  desc);
+    0: jdbc:drill:zk=local> Select b.name
+    from dfs.`<path-to-yelp-dataset>/yelp/yelp_academic_dataset_business.json` b
+    where b.business_id in (SELECT r.business_id
+    FROM dfs.`<path-to-yelp-dataset>/yelp/yelp_academic_dataset_review.json` r
+    GROUP BY r.business_id having sum(r.votes.cool) > 2000
+    order by sum(r.votes.cool) desc);
     +-------------------------------+
     |             name              |
     +-------------------------------+
@@ -323,14 +322,14 @@ of the reviews themselves.
 
 Note that Drill views are lightweight, and can just be created in the local
 file system. Drill in standalone mode comes with a dfs.tmp workspace, which we
-can use to create views (or you can can define your own workspaces on a local
+can use to create views (or you can define your own workspaces on a local
 or distributed file system). If you want to persist the data physically
-instead of in a logical view, you can use CREATE TABLE AS SELECT syntax.
+instead of querying it through a logical view, you can use CREATE TABLE AS SELECT syntax.
 
-    0: jdbc:drill:zk=local> create or replace view dfs.tmp.businessreviews as 
-    Select b.name,b.stars,b.state,b.city,r.votes.funny,r.votes.useful,r.votes.cool, r.`date` 
-    from dfs.`/users/nrentachintala/Downloads/yelp/yelp_academic_dataset_business.json` b, dfs.`/users/nrentachintala/Downloads/yelp/yelp_academic_dataset_review.json` r 
-    where r.business_id=b.business_id
+    0: jdbc:drill:zk=local> create or replace view dfs.tmp.businessreviews as
+    Select b.name, b.stars, b.state, b.city, r.votes.funny, r.votes.useful, r.votes.cool, r.`date`
+    from dfs.`<path-to-yelp-dataset>/yelp/yelp_academic_dataset_business.json` b, dfs.`<path-to-yelp-dataset>/yelp/yelp_academic_dataset_review.json` r
+    where r.business_id = b.business_id
     +------------+-----------------------------------------------------------------+
     |     ok     |                           summary                               |
     +------------+-----------------------------------------------------------------+
@@ -346,7 +345,7 @@ Let’s get the total number of records from the view.
     | 1125458    |
     +------------+
 
-In addition to these queries, you can get many more deeper insights using
+In addition to these queries, you can get many more deep insights using
 Drill’s [SQL functionality]({{ site.baseurl }}/docs/sql-reference). If you are not comfortable with writing queries manually, you
 can use a BI/Analytics tools such as Tableau/MicroStrategy to query raw
 files/Hive/HBase data or Drill-created views directly using Drill [ODBC/JDBC
@@ -362,8 +361,8 @@ data so you can apply even deeper SQL functionality. Here is a sample query:
 
 #### Get a flattened list of categories for each business
 
-    0: jdbc:drill:zk=local> select name, flatten(categories) as category 
-    from dfs.`/users/nrentachintala/Downloads/yelp/yelp_academic_dataset_business.json`  limit 20;
+    0: jdbc:drill:zk=local> select name, flatten(categories) as category
+    from dfs.`<path-to-yelp-dataset>/yelp/yelp_academic_dataset_business.json`  limit 20;
     +-----------------------------+---------------------------------+
     | name                        | category                        |
     +-----------------------------+---------------------------------+
@@ -391,9 +390,9 @@ data so you can apply even deeper SQL functionality. Here is a sample query:
 
 #### Top categories used in business reviews
 
-    0: jdbc:drill:zk=local> select celltbl.catl, count(celltbl.catl) categorycnt 
-    from (select flatten(categories) catl from dfs.`/yelp_academic_dataset_business.json` ) celltbl 
-    group by celltbl.catl 
+    0: jdbc:drill:zk=local> select celltbl.catl, count(celltbl.catl) categorycnt
+    from (select flatten(categories) catl from dfs.`<path-to-yelp-dataset>/yelp/yelp_academic_dataset_business.json` ) celltbl
+    group by celltbl.catl
     order by count(celltbl.catl) desc limit 10 ;
     +------------------+-------------+
     | catl             | categorycnt |
@@ -415,7 +414,6 @@ Stay tuned for more features and upcoming activities in the Drill community.
 To learn more about Drill, please refer to the following resources:
 
   * Download Drill here: <http://getdrill.org/drill/download>
-  * [10 reasons we think Drill is cool]({{site.baseurl}}/docs/why-drill)
-  * [A simple 10-minute tutorial]({{ site.baseurl }}/docs/drill-in-10-minutes>)
+  * [10 reasons we think Drill is cool]({{ site.baseurl }}/docs/why-drill)
+  * [A simple 10-minute tutorial]({{ site.baseurl }}/docs/drill-in-10-minutes)
   * [More tutorials]({{ site.baseurl }}/docs/tutorials-introduction/)
-


### PR DESCRIPTION
Remove an extra "the" from the Tutorials TOC.
Fixed some typos, improved query instructions, and NOTE TO DOC in "Drill in 10 Minutes."